### PR TITLE
Correction bug : les contraintes du mot de passe n'étaient pas vérifiées

### DIFF
--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -34,8 +34,8 @@ class UserService extends AbstractController
          * Sinon, le mot de passe n'est pas hashé et les contraintes de validator bloqueront l'entrée de la donnée.
          */
         if ($data->getPassword()
-            && preg_match('/^(?=.*\W)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}$/',$data->getPassword())
-            && !empty($data->getPassword())) {
+            && preg_match('/^(?=.*\W)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}$/', $data->getPassword()))
+        {
             $data->setPassword
             (
                 $this->passwordHasher->hashPassword($data, $data->getPassword())

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -29,10 +29,18 @@ class UserService extends AbstractController
     public function makePasswordHash(User $data): User
     {
 
-        $data->setPassword
-        (
-            $this->passwordHasher->hashPassword( $data, $data->getPassword() )
-        );
+        /**
+         * Vérifie si le mot de passe répond aux exigences de la regex et s'il est non null et non vide.
+         * Sinon, le mot de passe n'est pas hashé et les contraintes de validator bloqueront l'entrée de la donnée.
+         */
+        if ($data->getPassword()
+            && preg_match('/^(?=.*\W)(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}$/',$data->getPassword())
+            && !empty($data->getPassword())) {
+            $data->setPassword
+            (
+                $this->passwordHasher->hashPassword($data, $data->getPassword())
+            );
+        }
 
         $this->updateUser($data);
 


### PR DESCRIPTION
Validator intervient après que le controller ait fait ses opérations. 
Hors dans ses opérations il y a le hashage du mot de passe. 
Une fois le hashage fait, toutes les exigences de la regex sur le mot de passe sont remplies.

Correction apporté : vérification des contraintes dans le contrôleur. Si les contraintes ne sont pas remplies, alors le mot de passe n'est pas hashé.

Validator peut donc bloquer l'entrée de la donnée.