### PR TITLE
Ajout d'unicité sur les propriétés name des entités, pseudo de Cutomer et mail de User

### DIFF
--- a/migrations/Version20220126171953.php
+++ b/migrations/Version20220126171953.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220126171953 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_6BAF78705E237E06 ON ingredient (name)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_6BAF78705E237E06 ON ingredient');
+    }
+}

--- a/migrations/Version20220126175556.php
+++ b/migrations/Version20220126175556.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220126175556 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_81398E0986CC499D ON customer (pseudo)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_D28FE7BF5E237E06 ON ingredient_type (name)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8F7B17A25E237E06 ON potion_type (name)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_20F33ED15E237E06 ON tool (name)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_81398E0986CC499D ON customer');
+        $this->addSql('DROP INDEX UNIQ_D28FE7BF5E237E06 ON ingredient_type');
+        $this->addSql('DROP INDEX UNIQ_8F7B17A25E237E06 ON potion_type');
+        $this->addSql('DROP INDEX UNIQ_20F33ED15E237E06 ON tool');
+    }
+}

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -15,6 +15,7 @@ use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 #[
     ApiResource(
@@ -35,6 +36,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 ]
 /**
  * @ORM\Entity(repositoryClass=CustomerRepository::class)
+ * @UniqueEntity("pseudo", message="ce pseudo existe déjà")
  */
 class Customer extends User
 {
@@ -45,7 +47,7 @@ class Customer extends User
     private Uuid $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      * @Assert\NotBlank(message="ce champ est recquis")
      * @Assert\NotNull(message="ce champ est recquis")
      */

--- a/src/Entity/Ingredient.php
+++ b/src/Entity/Ingredient.php
@@ -7,9 +7,11 @@ use App\Repository\IngredientRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * @ORM\Entity(repositoryClass=IngredientRepository::class)
+ * @UniqueEntity("name", message="ce nom existe déjà")
  */
 #[ApiResource(
     collectionOperations: [
@@ -24,6 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     denormalizationContext: ['groups' => ['write:item']],
     normalizationContext: ['groups' => ['read:item']]
 )]
+
 class Ingredient
 {
     /**
@@ -35,7 +38,7 @@ class Ingredient
     private int $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      * @Assert\NotBlank(message="ce champ est recquis")
      * @Assert\NotNull(message="ce champ est recquis")
      */

--- a/src/Entity/IngredientType.php
+++ b/src/Entity/IngredientType.php
@@ -8,9 +8,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * @ORM\Entity(repositoryClass=IngredientTypeRepository::class)
+ * @UniqueEntity("name", message="ce nom existe déjà")
  */
 #[ApiResource(
     collectionOperations: [
@@ -36,7 +38,7 @@ class IngredientType
     private int $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      */
     #[Groups(['read:item', 'write:item'])]
     private ?string $name;

--- a/src/Entity/PotionType.php
+++ b/src/Entity/PotionType.php
@@ -9,9 +9,11 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * @ORM\Entity(repositoryClass=PotionTypeRepository::class)
+ * @UniqueEntity("name", message="ce nom existe déjà")
  */
 #[ApiResource(
     collectionOperations: [
@@ -37,7 +39,7 @@ class PotionType
     private int $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      * @Assert\NotBlank(message="ce champ est recquis")
      * @Assert\NotNull(message="ce champ est recquis")
      */

--- a/src/Entity/Tool.php
+++ b/src/Entity/Tool.php
@@ -8,10 +8,12 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass=ToolRepository::class)
+ * @UniqueEntity("name", message="ce nom existe déjà")
  */
 #[ApiResource(
     collectionOperations: [
@@ -37,7 +39,7 @@ class Tool
     private int $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      * @Assert\NotBlank(message="ce champ est recquis")
      * @Assert\NotNull(message="ce champ est recquis")
      */

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,12 +11,14 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * @ORM\Entity(repositoryClass=UserRepository::class)
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"administrator"="Administrator", "customer"="Customer"})
+ * @UniqueEntity("email", message="cet email existe déjà")
  */
 Abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
 {


### PR DESCRIPTION
Cette correction modifie la base de données : il y a deux migrations à jouer : doctrine:migration:migrate.

Si des ingrédients, type d'ingrédient, type de potion ou outil ont le même nom dans la base de données, il faudra les supprimer pour que la migration fonctionne.
De même si des customers ont le même nom ou le même mail.
De même si des administrateurs ont le même mail.

Cette correction ajoute aussi une contrainte de validation de doctrine. Le message renvoyé doit donc être en français.