### PR TITLE
Authentification par email et username

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -12,7 +12,6 @@ security:
         app_user_provider:
             entity:
                 class: App\Entity\User
-                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/

--- a/migrations/Version20220302143811.php
+++ b/migrations/Version20220302143811.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220302143811 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_81398E0986CC499D ON customer');
+        $this->addSql('ALTER TABLE customer DROP pseudo');
+        $this->addSql('ALTER TABLE user ADD username VARCHAR(255) NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_8D93D649F85E0677 ON user (username)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE customer ADD pseudo VARCHAR(255) NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_81398E0986CC499D ON customer (pseudo)');
+        $this->addSql('DROP INDEX UNIQ_8D93D649F85E0677 ON user');
+        $this->addSql('ALTER TABLE user DROP username');
+    }
+}

--- a/src/DataFixtures/UserFixtures.php
+++ b/src/DataFixtures/UserFixtures.php
@@ -48,6 +48,7 @@ class UserFixtures extends Fixture
         $admin = new Administrator();
 
         $admin
+            ->setName('Admin')
             ->setEmail('admin@example.com')
             ->setPassword('Pa$$w0rd')
             ->setStatus(Constant::STATUS_ACTIVATED);
@@ -60,6 +61,7 @@ class UserFixtures extends Fixture
         $adminDisabled = new Administrator();
 
         $adminDisabled
+            ->setName('AdminDisabled')
             ->setEmail('adminDisabled@example.com')
             ->setPassword('Pa$$w0rd')
             ->setStatus(Constant::STATUS_DISABLED);
@@ -72,10 +74,10 @@ class UserFixtures extends Fixture
         $customer = new Customer();
 
         $customer
+            ->setName('Customer')
             ->setEmail('customer@example.com')
             ->setPassword('Pa$$w0rd')
             ->setAlchemistLevel('1')
-            ->setPseudo('customer')
             ->setAlchemistTool($tool)
             ->setStatus(Constant::STATUS_ACTIVATED);
 
@@ -87,10 +89,10 @@ class UserFixtures extends Fixture
         $customerPending = new Customer();
 
         $customerPending
+            ->setName('CustomerPending')
             ->setEmail('customerPending@example.com')
             ->setPassword('Pa$$w0rd')
             ->setAlchemistLevel('1')
-            ->setPseudo('customerPending')
             ->setAlchemistTool($tool)
             ->setStatus(Constant::STATUS_PENDING);
 
@@ -102,10 +104,10 @@ class UserFixtures extends Fixture
         $customerDisabled = new Customer();
 
         $customerDisabled
+            ->setName('CustomerDisabled')
             ->setEmail('customerDisabled@example.com')
             ->setPassword('Pa$$w0rd')
             ->setAlchemistLevel('1')
-            ->setPseudo('customerDisabled')
             ->setAlchemistTool($tool)
             ->setStatus(Constant::STATUS_DISABLED);
 
@@ -117,10 +119,10 @@ class UserFixtures extends Fixture
         $customerToolDisabled = new Customer();
 
         $customerToolDisabled
+            ->setName('CustomerToolDisabled')
             ->setEmail('customerToolDisabled@example.com')
             ->setPassword('Pa$$w0rd')
             ->setAlchemistLevel('1')
-            ->setPseudo('customerToolDisabled')
             ->setAlchemistTool($toolDisabled)
             ->setStatus(Constant::STATUS_ACTIVATED);
 

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -42,7 +42,6 @@ use App\Constants\InvalidMessage;
 ]
 /**
  * @ORM\Entity(repositoryClass=CustomerRepository::class)
- * @UniqueEntity("pseudo", message="ce pseudo existe déjà")
  */
 class Customer extends User
 {
@@ -51,16 +50,6 @@ class Customer extends User
      * @ORM\Column(type="uuid", unique=true)
      */
     private Uuid $id;
-
-    /**
-     * @ORM\Column(type="string", length=255, unique=true)
-     */
-    #[Assert\NotBlank(message: InvalidMessage::NOT_BLANK)]
-    #[Assert\NotNull(message: InvalidMessage::NOT_NULL)]
-    #[Assert\Length(max: 255, maxMessage: InvalidMessage::MAX_MESSAGE)]
-    #[Assert\Type(type: "string", message: InvalidMessage::BAD_TYPE)]
-    #[Groups(['read:item', 'write:item'])]
-    private string $pseudo;
 
     /**
      * @ORM\Column(type="integer")
@@ -89,18 +78,6 @@ class Customer extends User
     {
         parent::__construct();
         $this->potions = new ArrayCollection();
-    }
-
-    public function getPseudo(): ?string
-    {
-        return $this->pseudo;
-    }
-
-    public function setPseudo(string $pseudo): self
-    {
-        $this->pseudo = $pseudo;
-
-        return $this;
     }
 
     public function getAlchemistLevel(): ?int

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -20,6 +20,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"administrator"="Administrator", "customer"="Customer"})
  * @UniqueEntity("email", message="cet email existe déjà")
+ * @UniqueEntity("pseudo", message="ce pseudo existe déjà")
  */
 Abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
@@ -29,6 +30,16 @@ Abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     #[Groups(['read:item'])]
     private Uuid $id;
+
+    /**
+     * @ORM\Column(type="string", length=255, unique=true)
+     */
+    #[Assert\NotBlank(message: InvalidMessage::NOT_BLANK)]
+    #[Assert\NotNull(message: InvalidMessage::NOT_NULL)]
+    #[Assert\Length(max: 255, maxMessage: InvalidMessage::MAX_MESSAGE)]
+    #[Assert\Type(type: "string", message: InvalidMessage::BAD_TYPE)]
+    #[Groups(['read:item', 'write:item'])]
+    private string $username;
 
     /**
      * @ORM\Column(type="string", length=180, unique=true)
@@ -93,6 +104,18 @@ Abstract class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function getId(): UuidV4
     {
         return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->username;
+    }
+
+    public function setName(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
     }
 
     public function getEmail(): ?string

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -5,9 +5,11 @@ namespace App\Repository;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @method User|null find($id, $lockMode = null, $lockVersion = null)
@@ -15,11 +17,31 @@ use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
  * @method User[]    findAll()
  * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface, UserLoaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+    }
+
+    // utilisé pour permettre l'authentification par email ou username
+    public function loadUserByIdentifier(string $usernameOrEmail): ?User
+    {
+        $entityManager = $this->getEntityManager();
+
+        return $entityManager->createQuery(
+            'SELECT u
+                FROM App\Entity\User u
+                WHERE u.username = :query
+                OR u.email = :query'
+        )
+            ->setParameter('query', $usernameOrEmail)
+            ->getOneOrNullResult();
+    }
+
+    public function loadUserByUsername(string $usernameOrEmail): ?User
+    {
+        return $this->loadUserByIdentifier($usernameOrEmail);
     }
 
     /**


### PR DESCRIPTION
Le système d'authentification est basé sur la classe User.

Pour permettre la connexion de l'utilisateur avec son pseudo, il fallait que cette propriété soit dans la classe User et non Customer.

Actions effectuées : 
- Retrait de la propriété pseudo dans Customer
- Ajout de la propriété Username dans User (username est un nom qui m'a semblé plus approprié que pseudo. Désormais les admin auront aussi un username du fait de la non nullité de cette propriété. Ce username pourra être utilisé par le front pour afficher l'utilisateur courrant.)
- Modification des tables concernées par cette classe et donc création d'une nouvelle migration. (warning sur la prod : il faudra supprimer / recréer la base)
- Modification des fixtures en conséquences. (warning : postman ne peut plus fonctionner pour ces classes)