### PR TITLE
geeko 75 - personnalisation de GET/GETALL TOOLS

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -10,3 +10,12 @@ api_platform:
             apiKey:
                 name: Authorization
                 type: header
+    exception_to_status:
+        Symfony\Component\Serializer\Exception\ExceptionInterface: 400
+        ApiPlatform\Core\Exception\InvalidArgumentException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
+        ApiPlatform\Core\Exception\FilterValidationException: 400
+        Doctrine\ORM\OptimisticLockException: 409
+
+        ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
+
+        App\Exception\ToolNotFoundException: 404

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Constants;
+
+class ErrorMessage
+{
+    const TOOL_NOT_FOUND = "Outil indisponible";
+}

--- a/src/DataProvider/RecipeDataProvider.php
+++ b/src/DataProvider/RecipeDataProvider.php
@@ -22,6 +22,7 @@ class RecipeDataProvider implements ContextAwareCollectionDataProviderInterface,
         $this->recipeRepository = $recipeRepository;
     }
 
+    // Calcule la moyenne de la valeur d'une potion
     private function averageCalc($potions): string
     {
         $values = [];

--- a/src/DataProvider/ToolProvider.php
+++ b/src/DataProvider/ToolProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
+use App\Entity\Tool;
+use App\Repository\ToolRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+use App\Constants\ErrorMessage;
+use App\Exception\ToolNotFoundException;
+use Exception;
+
+class ToolProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+
+    private $collectionDataProvider;
+    private  $toolRepository;
+    private $security;
+
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ToolRepository $toolRepository, Security $security)
+    {
+        $this->collectionDataProvider = $collectionDataProvider;
+        $this->toolRepository = $toolRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->toolRepository->findAll();
+        }
+
+        return $this->toolRepository->findToolsByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+        $tool = $this->toolRepository->find($id);
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN) {
+            return $tool;
+        }
+
+        if ($tool->getStatus() === Constant::STATUS_DISABLED) {
+            return throw new ToolNotFoundException(ErrorMessage::TOOL_NOT_FOUND);
+        }
+
+        return $tool;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return Tool::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/ToolProvider.php
+++ b/src/DataProvider/ToolProvider.php
@@ -39,7 +39,7 @@ class ToolProvider implements ContextAwareCollectionDataProviderInterface,
             return $this->toolRepository->findAll();
         }
 
-        return $this->toolRepository->findToolsByStatus(Constant::STATUS_ACTIVATED);
+        return $this->toolRepository->findByStatus(Constant::STATUS_ACTIVATED);
     }
 
     public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])

--- a/src/Exception/ToolNotFoundException.php
+++ b/src/Exception/ToolNotFoundException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Exception;
+
+final class ToolNotFoundException extends \Exception{}

--- a/src/Repository/ToolRepository.php
+++ b/src/Repository/ToolRepository.php
@@ -19,8 +19,8 @@ class ToolRepository extends ServiceEntityRepository
         parent::__construct($registry, Tool::class);
     }
 
-    // Retourn les outils avec un statut activé uniquement
-    public function findToolsByStatus($value)
+    // Retourne les outils selon le statut demandé
+    public function findByStatus($value)
     {
         return $this->createQueryBuilder('t')
             ->andWhere('t.status = :val')

--- a/src/Repository/ToolRepository.php
+++ b/src/Repository/ToolRepository.php
@@ -19,6 +19,16 @@ class ToolRepository extends ServiceEntityRepository
         parent::__construct($registry, Tool::class);
     }
 
+    // Retourn les outils avec un statut activé uniquement
+    public function findToolsByStatus($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getResult();
+    }
+
     // /**
     //  * @return Tool[] Returns an array of Tool objects
     //  */


### PR DESCRIPTION
Empêche les requêtes GET et GETALL TOOLS de renvoyer les items lorsque leur statut est "disabled" et que l'utilisateur n'est pas un admin.

actions :
- Création d'un dataProvider qui vérifie le statut du/des item(s) renvoyé(s) et le rôle de l'utilisateur.
- Création d'une exception ToolNotFound.
- Lancement de cette erreur par le dataprovider lorsque l'item demandé a un statut disabled.
- Paramétrage d'ApiPlatform pour qu'il retourne un code 404 lorsque l'exception ToolNotFound est lancée.

- hors sujet : ajout d'un commentaire dans le RecipeDataProvider.

warning: 
- le dataprovider est appelé par les requêtes PATCH/POST avant de vérifier si l'utilisateur a les droits pour faire un PATCH/POST car la requête passe par un GET. Le code 404:ToolNotFound est donc retourné avant le code 401:Unauthorized. Ticket créé dans Jira pour approfondir la question.