### PR TITLE
Geeko 80 customer : personnalisation du dataprovider de customer

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -18,6 +18,7 @@ api_platform:
 
         ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
 
+        App\Exception\CustomerNotFoundException: 404
         App\Exception\IngredientNotFoundException: 404
         App\Exception\IngredientTypeNotFoundException: 404
         App\Exception\PotionNotFoundException: 404

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -4,6 +4,7 @@ namespace App\Constants;
 
 class ErrorMessage
 {
+    const CUSTOMER_NOT_FOUND = "Utilisateur indisponible";
     const INGREDIENT_NOT_FOUND = "Ingrédient indisponible";
     const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
     const POTION_NOT_FOUND = "Potion indisponible";

--- a/src/DataProvider/CustomerProvider.php
+++ b/src/DataProvider/CustomerProvider.php
@@ -37,13 +37,14 @@ final class CustomerProvider implements ContextAwareCollectionDataProviderInterf
     // Exécute un getAll sur Customer selon le role de l'utilisateur
     public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
     {
-        $user = $this->security->getUser();
         $data = $this->customerRepository->findAll();
 
         if(!$data)
         {
             throw new CustomerNotFoundException();
         }
+
+        $user = $this->security->getUser();
 
         // Si l'utilisateur est un admin, renvoie toutes les données des customers
         if($user && $user->getRoles() === Constant::ROLE_ADMIN)

--- a/src/Exception/CustomerNotFoundException.php
+++ b/src/Exception/CustomerNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class CustomerNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::CUSTOMER_NOT_FOUND);
+    }
+}

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -19,22 +19,15 @@ class CustomerRepository extends ServiceEntityRepository
         parent::__construct($registry, Customer::class);
     }
 
-    // /**
-    //  * @return Customer[] Returns an array of Customer objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    // Retourne les customers selon le statut demandé
+    public function findByStatus($value)
     {
-        return $this->createQueryBuilder('c')
-            ->andWhere('c.exampleField = :val')
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
             ->setParameter('val', $value)
-            ->orderBy('c.id', 'ASC')
-            ->setMaxResults(10)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
 
     /*
     public function findOneBySomeField($value): ?Customer


### PR DESCRIPTION
-le endpoint GETALL est modifié pour throw une exception en cas d'absence de données
- le endoint GET n'est pas modifié car seul l'admin peut faire un GET{id}. Lorsqu'un customer le fait, il ne peut qu'apeller son propre id. Il doit être connecté pour le faire et donc ne pourra pas appeler son propre id dans le cas où son compte est disabled.

warning : 
- bug repéré : Symfony ne renvoie pas la valeur de la propriété username lorsqu'on la lui demande via les endpoints GET et GETALL. à la place il renvoie le mail. C'est sûrement lié au système d'authentification. ticket jira ouvert à ce sujet.