### PR TITLE
Geeko-64 : personnalisation des endpoints GET pour tenir compte du statut 

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -23,5 +23,6 @@ api_platform:
         App\Exception\IngredientTypeNotFoundException: 404
         App\Exception\PotionNotFoundException: 404
         App\Exception\PotionTypeNotFoundException: 404
+        App\Exception\RecipeNotFoundException: 404
         App\Exception\ToolNotFoundException: 404
 

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -18,7 +18,9 @@ api_platform:
 
         ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
 
-        App\Exception\ToolNotFoundException: 404
-        App\Exception\PotionTypeNotFoundException: 404
-        App\Exception\IngredientTypeNotFoundException: 404
         App\Exception\IngredientNotFoundException: 404
+        App\Exception\IngredientTypeNotFoundException: 404
+        App\Exception\PotionNotFoundException: 404
+        App\Exception\PotionTypeNotFoundException: 404
+        App\Exception\ToolNotFoundException: 404
+

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -18,6 +18,7 @@ api_platform:
 
         ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
 
+        App\Exception\CustomerNotFoundException: 404
         App\Exception\IngredientNotFoundException: 404
         App\Exception\IngredientTypeNotFoundException: 404
         App\Exception\PotionNotFoundException: 404

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -20,3 +20,4 @@ api_platform:
 
         App\Exception\ToolNotFoundException: 404
         App\Exception\PotionTypeNotFoundException: 404
+        App\Exception\IngredientTypeNotFoundException: 404

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -21,3 +21,4 @@ api_platform:
         App\Exception\ToolNotFoundException: 404
         App\Exception\PotionTypeNotFoundException: 404
         App\Exception\IngredientTypeNotFoundException: 404
+        App\Exception\IngredientNotFoundException: 404

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -10,3 +10,12 @@ api_platform:
             apiKey:
                 name: Authorization
                 type: header
+    exception_to_status:
+        Symfony\Component\Serializer\Exception\ExceptionInterface: 400
+        ApiPlatform\Core\Exception\InvalidArgumentException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST
+        ApiPlatform\Core\Exception\FilterValidationException: 400
+        Doctrine\ORM\OptimisticLockException: 409
+
+        ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
+
+        App\Exception\ToolNotFoundException: 404

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -19,3 +19,4 @@ api_platform:
         ApiPlatform\Core\Bridge\Symfony\Validator\Exception\ValidationException: !php/const Symfony\Component\HttpFoundation\Response::HTTP_UNPROCESSABLE_ENTITY
 
         App\Exception\ToolNotFoundException: 404
+        App\Exception\PotionTypeNotFoundException: 404

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -4,8 +4,9 @@ namespace App\Constants;
 
 class ErrorMessage
 {
-    const TOOL_NOT_FOUND = "Outil indisponible";
-    const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
-    const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
     const INGREDIENT_NOT_FOUND = "Ingrédient indisponible";
+    const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
+    const POTION_NOT_FOUND = "Potion indisponible";
+    const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
+    const TOOL_NOT_FOUND = "Outil indisponible";
 }

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -7,4 +7,5 @@ class ErrorMessage
     const TOOL_NOT_FOUND = "Outil indisponible";
     const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
     const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
+    const INGREDIENT_NOT_FOUND = "Ingrédient indisponible";
 }

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -5,4 +5,5 @@ namespace App\Constants;
 class ErrorMessage
 {
     const TOOL_NOT_FOUND = "Outil indisponible";
+    const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
 }

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Constants;
+
+class ErrorMessage
+{
+    const TOOL_NOT_FOUND = "Outil indisponible";
+}

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -9,5 +9,6 @@ class ErrorMessage
     const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
     const POTION_NOT_FOUND = "Potion indisponible";
     const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
+    const RECIPE_NOT_FOUND = "Recette indisponible";
     const TOOL_NOT_FOUND = "Outil indisponible";
 }

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -6,4 +6,5 @@ class ErrorMessage
 {
     const TOOL_NOT_FOUND = "Outil indisponible";
     const POTION_TYPE_NOT_FOUND = "Le type de la potion n'existe pas";
+    const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
 }

--- a/src/Constants/ErrorMessage.php
+++ b/src/Constants/ErrorMessage.php
@@ -4,6 +4,7 @@ namespace App\Constants;
 
 class ErrorMessage
 {
+    const CUSTOMER_NOT_FOUND = "Utilisateur indisponible";
     const INGREDIENT_NOT_FOUND = "Ingrédient indisponible";
     const INGREDIENT_TYPE_NOT_FOUND = "Ce type d'ingrédient n'existe pas";
     const POTION_NOT_FOUND = "Potion indisponible";

--- a/src/DataProvider/CustomerProvider.php
+++ b/src/DataProvider/CustomerProvider.php
@@ -2,34 +2,49 @@
 
 namespace App\DataProvider;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\CollectionDataProvider;
-use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use App\Entity\Customer;
+use App\Exception\CustomerNotFoundException;
 use App\Repository\CustomerRepository;
 use App\Constants\Constant;
 use Symfony\Component\Security\Core\Security;
 
-final class CustomerCollectionDataProvider implements ContextAwareCollectionDataProviderInterface,
+final class CustomerProvider implements ContextAwareCollectionDataProviderInterface,
     RestrictedDataProviderInterface
 {
-    private $collectionDataProvider;
-    private $customerRepository;
-    private $security;
+    private CustomerRepository $customerRepository;
+    private Security $security;
 
-    public function __construct(CustomerRepository $customerRepository, CollectionDataProviderInterface $collectionDataProvider, Security $security)
+    public function __construct(CustomerRepository $customerRepository, Security $security)
     {
-        $this->collectionDataProvider = $collectionDataProvider;
         $this->customerRepository = $customerRepository;
         $this->security = $security;
+    }
+
+    private function setAnonymousData($customer): void
+    {
+        $customer
+            ->setEmail("hidden@anonymous.com")
+            ->setStatus("hidden")
+            ->setPassword("hidden")
+            ->setCreatedAt("hidden")
+            ->setUpdatedAt("hidden")
+            ->setTokenPassword("hidden");
     }
 
     // Exécute un getAll sur Customer selon le role de l'utilisateur
     public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
     {
-        $user = $this->security->getUser();
         $data = $this->customerRepository->findAll();
+
+        if(!$data)
+        {
+            throw new CustomerNotFoundException();
+        }
+
+        $user = $this->security->getUser();
 
         // Si l'utilisateur est un admin, renvoie toutes les données des customers
         if($user && $user->getRoles() === Constant::ROLE_ADMIN)
@@ -40,13 +55,7 @@ final class CustomerCollectionDataProvider implements ContextAwareCollectionData
         // Sinon, ne renvoie que les données non sensibles
         foreach ($data as $customer)
         {
-            $customer
-                ->setEmail("hidden@anonymous.com")
-                ->setStatus("hidden")
-                ->setPassword("hidden")
-                ->setCreatedAt("hidden")
-                ->setUpdatedAt("hidden")
-                ->setTokenPassword("hidden");
+            $this->setAnonymousData($customer);
         }
         return $data;
     }

--- a/src/DataProvider/IngredientProvider.php
+++ b/src/DataProvider/IngredientProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\Ingredient;
+use App\Exception\IngredientNotFoundException;
+use App\Repository\IngredientRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+
+class IngredientProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+    private IngredientRepository $ingredientRepository;
+    private Security $security;
+
+    public function __construct(IngredientRepository $ingredientRepository, Security $security)
+    {
+        $this->ingredientRepository = $ingredientRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->ingredientRepository->findAll();
+        }
+
+        return $this->ingredientRepository->findByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = []): Ingredient|null
+    {
+        $ingredient = $this->ingredientRepository->find($id);
+
+        if(!$ingredient)
+        {
+            throw new IngredientNotFoundException();
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $ingredient;
+        }
+
+        if ($ingredient->getStatus() === Constant::STATUS_DISABLED)
+        {
+            throw new IngredientNotFoundException();
+        }
+
+        return $ingredient;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return Ingredient::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/IngredientTypeProvider.php
+++ b/src/DataProvider/IngredientTypeProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\IngredientType;
+use App\Exception\IngredientTypeNotFoundException;
+use App\Repository\IngredientTypeRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+
+class IngredientTypeProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+    private IngredientTypeRepository $ingredientTypeRepository;
+    private Security $security;
+
+    public function __construct(IngredientTypeRepository $ingredientTypeRepository, Security $security)
+    {
+        $this->ingredientTypeRepository = $ingredientTypeRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->ingredientTypeRepository->findAll();
+        }
+
+        return $this->ingredientTypeRepository->findByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = []): IngredientType|null
+    {
+        $ingredientType = $this->ingredientTypeRepository->find($id);
+
+        if(!$ingredientType)
+        {
+            throw new IngredientTypeNotFoundException();
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN) {
+            return $ingredientType;
+        }
+
+        if ($ingredientType->getStatus() === Constant::STATUS_DISABLED) {
+            throw new IngredientTypeNotFoundException();
+        }
+
+        return $ingredientType;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return IngredientType::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/PotionProvider.php
+++ b/src/DataProvider/PotionProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\Potion;
+use App\Exception\PotionNotFoundException;
+use App\Repository\PotionRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+
+class PotionProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+    private PotionRepository $potionRepository;
+    private Security $security;
+
+    public function __construct(PotionRepository $potionRepository, Security $security)
+    {
+        $this->potionRepository = $potionRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->potionRepository->findAll();
+        }
+
+        return $this->potionRepository->findByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    {
+        $potion = $this->potionRepository->find($id);
+
+        if(!$potion) {
+            throw new PotionNotFoundException();
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN) {
+            return $potion;
+        }
+
+        if ($potion->getStatus() === Constant::STATUS_DISABLED) {
+            throw new PotionNotFoundException();
+        }
+
+        return $potion;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return Potion::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/PotionTypeProvider.php
+++ b/src/DataProvider/PotionTypeProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\PotionType;
+use App\Exception\PotionTypeNotFoundException;
+use App\Repository\PotionTypeRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+
+class PotionTypeProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+    private PotionTypeRepository $potionTypeRepository;
+    private Security $security;
+
+    public function __construct(PotionTypeRepository $potionTypeRepository, Security $security)
+    {
+        $this->potionTypeRepository = $potionTypeRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->potionTypeRepository->findAll();
+        }
+
+        return $this->potionTypeRepository->findByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = []): PotionType|null
+    {
+        $potionType = $this->potionTypeRepository->find($id);
+
+        if(!$potionType)
+        {
+            throw new PotionTypeNotFoundException();
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $potionType;
+        }
+
+        if ($potionType->getStatus() === Constant::STATUS_DISABLED)
+        {
+            throw new PotionTypeNotFoundException();
+        }
+
+        return $potionType;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return PotionType::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/RecipeDataProvider.php
+++ b/src/DataProvider/RecipeDataProvider.php
@@ -22,6 +22,7 @@ class RecipeDataProvider implements ContextAwareCollectionDataProviderInterface,
         $this->recipeRepository = $recipeRepository;
     }
 
+    // Calcule la moyenne de la valeur d'une potion
     private function averageCalc($potions): string
     {
         $values = [];

--- a/src/DataProvider/RecipeDataProvider.php
+++ b/src/DataProvider/RecipeDataProvider.php
@@ -2,24 +2,25 @@
 
 namespace App\DataProvider;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\ItemDataProvider;
-use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Constants\Constant;
 use App\Entity\Recipe;
+use App\Exception\RecipeNotFoundException;
 use App\Repository\RecipeRepository;
+use Symfony\Component\Security\Core\Security;
 
 class RecipeDataProvider implements ContextAwareCollectionDataProviderInterface,
     RestrictedDataProviderInterface, ItemDataProviderInterface
 {
-    private $collectionDataProvider;
-    private $recipeRepository;
+    private RecipeRepository $recipeRepository;
+    private Security $security;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, RecipeRepository $recipeRepository)
+    public function __construct(RecipeRepository $recipeRepository, Security $security)
     {
-        $this->collectionDataProvider = $collectionDataProvider;
         $this->recipeRepository = $recipeRepository;
+        $this->security = $security;
     }
 
     // Calcule la moyenne de la valeur d'une potion
@@ -46,9 +47,21 @@ class RecipeDataProvider implements ContextAwareCollectionDataProviderInterface,
         $recipe->setAverageValue($average);
     }
 
-    public function getCollection(string $resourceClass, string $operationName = null, array $context = []): array
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = []): array|null
     {
-        $recipes = $this->recipeRepository->findAll();
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            $recipes = $this->recipeRepository->findAll();
+        } else {
+            $recipes = $this->recipeRepository->findByStatus(Constant::STATUS_ACTIVATED);
+        }
+
+        if(!$recipes)
+        {
+            throw new RecipeNotFoundException();
+        }
 
         foreach ($recipes as $recipe)
         {
@@ -62,6 +75,23 @@ class RecipeDataProvider implements ContextAwareCollectionDataProviderInterface,
     public function getItem(string $resourceClass, $id, string $operationName = null, array $context = []): ?Recipe
     {
         $recipe = $this->recipeRepository->find($id);
+
+        if(!$recipe) {
+            throw new RecipeNotFoundException();
+        }
+
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            $this->setAverage($recipe);
+            return $recipe;
+        }
+
+        if($recipe->getStatus() === Constant::STATUS_DISABLED)
+        {
+            throw new RecipeNotFoundException();
+        }
 
         $this->setAverage($recipe);
 

--- a/src/DataProvider/ToolProvider.php
+++ b/src/DataProvider/ToolProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
+use App\Entity\Tool;
+use App\Repository\ToolRepository;
+use Symfony\Component\Security\Core\Security;
+use App\Constants\Constant;
+use App\Constants\ErrorMessage;
+use App\Exception\ToolNotFoundException;
+use Exception;
+
+class ToolProvider implements ContextAwareCollectionDataProviderInterface,
+    RestrictedDataProviderInterface, ItemDataProviderInterface
+{
+
+    private $collectionDataProvider;
+    private  $toolRepository;
+    private $security;
+
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ToolRepository $toolRepository, Security $security)
+    {
+        $this->collectionDataProvider = $collectionDataProvider;
+        $this->toolRepository = $toolRepository;
+        $this->security = $security;
+    }
+
+    public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+
+        if($user && $user->getRoles() === Constant::ROLE_ADMIN)
+        {
+            return $this->toolRepository->findAll();
+        }
+
+        return $this->toolRepository->findByStatus(Constant::STATUS_ACTIVATED);
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
+    {
+        $user = $this->security->getUser();
+        $tool = $this->toolRepository->find($id);
+
+        if ($user && $user->getRoles() === Constant::ROLE_ADMIN) {
+            return $tool;
+        }
+
+        if ($tool->getStatus() === Constant::STATUS_DISABLED) {
+            return throw new ToolNotFoundException(ErrorMessage::TOOL_NOT_FOUND);
+        }
+
+        return $tool;
+    }
+
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return Tool::class === $resourceClass;
+    }
+}

--- a/src/DataProvider/ToolProvider.php
+++ b/src/DataProvider/ToolProvider.php
@@ -18,14 +18,11 @@ use Exception;
 class ToolProvider implements ContextAwareCollectionDataProviderInterface,
     RestrictedDataProviderInterface, ItemDataProviderInterface
 {
+    private ToolRepository $toolRepository;
+    private Security $security;
 
-    private $collectionDataProvider;
-    private  $toolRepository;
-    private $security;
-
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, ToolRepository $toolRepository, Security $security)
+    public function __construct(ToolRepository $toolRepository, Security $security)
     {
-        $this->collectionDataProvider = $collectionDataProvider;
         $this->toolRepository = $toolRepository;
         $this->security = $security;
     }

--- a/src/DataProvider/ToolProvider.php
+++ b/src/DataProvider/ToolProvider.php
@@ -6,14 +6,12 @@ use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
-use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use App\Entity\Tool;
 use App\Repository\ToolRepository;
 use Symfony\Component\Security\Core\Security;
 use App\Constants\Constant;
 use App\Constants\ErrorMessage;
 use App\Exception\ToolNotFoundException;
-use Exception;
 
 class ToolProvider implements ContextAwareCollectionDataProviderInterface,
     RestrictedDataProviderInterface, ItemDataProviderInterface

--- a/src/Exception/CustomerNotFoundException.php
+++ b/src/Exception/CustomerNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class CustomerNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::CUSTOMER_NOT_FOUND);
+    }
+}

--- a/src/Exception/IngredientNotFoundException.php
+++ b/src/Exception/IngredientNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class IngredientNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::INGREDIENT_NOT_FOUND);
+    }
+}

--- a/src/Exception/IngredientTypeNotFoundException.php
+++ b/src/Exception/IngredientTypeNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class IngredientTypeNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::INGREDIENT_TYPE_NOT_FOUND);
+    }
+}

--- a/src/Exception/PotionNotFoundException.php
+++ b/src/Exception/PotionNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class PotionNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::POTION_NOT_FOUND);
+    }
+}

--- a/src/Exception/PotionTypeNotFoundException.php
+++ b/src/Exception/PotionTypeNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class PotionTypeNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::POTION_TYPE_NOT_FOUND);
+    }
+}

--- a/src/Exception/RecipeNotFoundException.php
+++ b/src/Exception/RecipeNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exception;
+
+use App\Constants\ErrorMessage;
+
+class RecipeNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct(ErrorMessage::RECIPE_NOT_FOUND);
+    }
+}

--- a/src/Exception/ToolNotFoundException.php
+++ b/src/Exception/ToolNotFoundException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Exception;
+
+final class ToolNotFoundException extends \Exception{}

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -19,22 +19,15 @@ class CustomerRepository extends ServiceEntityRepository
         parent::__construct($registry, Customer::class);
     }
 
-    // /**
-    //  * @return Customer[] Returns an array of Customer objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    // Retourne les customers selon le statut demandé
+    public function findByStatus($value)
     {
-        return $this->createQueryBuilder('c')
-            ->andWhere('c.exampleField = :val')
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
             ->setParameter('val', $value)
-            ->orderBy('c.id', 'ASC')
-            ->setMaxResults(10)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
 
     /*
     public function findOneBySomeField($value): ?Customer

--- a/src/Repository/IngredientRepository.php
+++ b/src/Repository/IngredientRepository.php
@@ -19,22 +19,15 @@ class IngredientRepository extends ServiceEntityRepository
         parent::__construct($registry, Ingredient::class);
     }
 
-    // /**
-    //  * @return Ingredient[] Returns an array of Ingredient objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    // Retourne les outils selon le statut demandé
+    public function findByStatus($value)
     {
-        return $this->createQueryBuilder('i')
-            ->andWhere('i.exampleField = :val')
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
             ->setParameter('val', $value)
-            ->orderBy('i.id', 'ASC')
-            ->setMaxResults(10)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
 
     /*
     public function findOneBySomeField($value): ?Ingredient

--- a/src/Repository/IngredientTypeRepository.php
+++ b/src/Repository/IngredientTypeRepository.php
@@ -19,22 +19,15 @@ class IngredientTypeRepository extends ServiceEntityRepository
         parent::__construct($registry, IngredientType::class);
     }
 
-    // /**
-    //  * @return IngredientType[] Returns an array of IngredientType objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    // Retourne les types d'ingrédient selon le statut demandé
+    public function findByStatus($value)
     {
-        return $this->createQueryBuilder('i')
-            ->andWhere('i.exampleField = :val')
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
             ->setParameter('val', $value)
-            ->orderBy('i.id', 'ASC')
-            ->setMaxResults(10)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
 
     /*
     public function findOneBySomeField($value): ?IngredientType

--- a/src/Repository/PotionRepository.php
+++ b/src/Repository/PotionRepository.php
@@ -19,22 +19,15 @@ class PotionRepository extends ServiceEntityRepository
         parent::__construct($registry, Potion::class);
     }
 
-    // /**
-    //  * @return Potion[] Returns an array of Potion objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    // Retourne les potions selon le statut demandé
+    public function findByStatus($value)
     {
-        return $this->createQueryBuilder('p')
-            ->andWhere('p.exampleField = :val')
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
             ->setParameter('val', $value)
-            ->orderBy('p.id', 'ASC')
-            ->setMaxResults(10)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
 
     /*
     public function findOneBySomeField($value): ?Potion

--- a/src/Repository/PotionTypeRepository.php
+++ b/src/Repository/PotionTypeRepository.php
@@ -19,6 +19,15 @@ class PotionTypeRepository extends ServiceEntityRepository
         parent::__construct($registry, PotionType::class);
     }
 
+    // Retourne les types de potion selon le statut demandé
+    public function findByStatus($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getResult();
+    }
     // /**
     //  * @return PotionType[] Returns an array of PotionType objects
     //  */

--- a/src/Repository/RecipeRepository.php
+++ b/src/Repository/RecipeRepository.php
@@ -19,6 +19,15 @@ class RecipeRepository extends ServiceEntityRepository
         parent::__construct($registry, Recipe::class);
     }
 
+    // Retourne les recettes selon le statut demandé
+    public function findByStatus($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getResult();
+    }
     // /**
     //  * @return Recipe[] Returns an array of Recipe objects
     //  */

--- a/src/Repository/ToolRepository.php
+++ b/src/Repository/ToolRepository.php
@@ -19,6 +19,16 @@ class ToolRepository extends ServiceEntityRepository
         parent::__construct($registry, Tool::class);
     }
 
+    // Retourne les outils selon le statut demandé
+    public function findByStatus($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.status = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getResult();
+    }
+
     // /**
     //  * @return Tool[] Returns an array of Tool objects
     //  */


### PR DESCRIPTION
Chaque endpoint GET a été personnalisé pour que les données ayant un statut disabled ne soit pas renvoyées dans le cas où l'utilisateur n'est pas admin.
Des code 404 sont lancés lorsqu'aucune entité n'est trouvé, un que son statut et disabled.